### PR TITLE
Change build flags

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -3,7 +3,8 @@ package main
 
 /*
 #include "./App/TEE.h"
-#cgo LDFLAGS: -I./App -L. -ltee 
+#cgo CFLAGS: -I./App
+#cgo LDFLAGS: -L. -ltee
 */
 import "C"
 


### PR DESCRIPTION
`-I` flag is CFLAGS not LDFLAGS

```
LD_LIBRARY_PATH=$LD_LIBRARY_PATH:. go run cgo.go
go build command-line-arguments: invalid flag in #cgo LDFLAGS: -I/home/emjay/workspace/go-with-intel-sgx/App
Makefile:225: recipe for target 'cgo' failed
```